### PR TITLE
DS-2986 Handle Aliased Dummy Variables

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipData
 Type: Package
 Title: Functions for extracting and describing data
-Version: 1.2.10
+Version: 1.2.11
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Functions for extracting data from formulas and

--- a/R/checks.R
+++ b/R/checks.R
@@ -202,7 +202,7 @@ CheckPredictionVariables <- function(object, newdata)
 #' @param level.counts A named integer vector which has the counts of each level that applies in this scenario,
 #'    the names of the vector are the level labels.
 #' @param warning.due.to.outlier.removal Logical to flag if this warning is being thrown only because of the automated outlier removal.
-#' @NoRd
+#' @noRd
 checkPredictionWarningMessage <- function(label, level.counts, warning.due.to.outlier.removal = FALSE)
 {
     levels <- names(level.counts)

--- a/R/missingdata.R
+++ b/R/missingdata.R
@@ -252,7 +252,7 @@ remapDataFrame <- function(dataframe)
                  "however suppled variable is ", sQuote(class(x)))
         return(x)
     })
-    as.data.frame(remapped.list)
+    as.data.frame(remapped.list, check.names = FALSE)
 }
 
 # Helper function for the dummy variable adjustment.

--- a/R/tidyrawdata.R
+++ b/R/tidyrawdata.R
@@ -69,7 +69,9 @@ TidyRawData <- function(data,
 
     ## handle variables of QDate class
     ## data.frame ensures ProcessQVariables also returns a data.frame
-    data <- flipTransformations::ProcessQVariables(data.frame(data, check.names = FALSE))  # can't have check.names = FALSE
+    data <- flipTransformations::ProcessQVariables(data.frame(data,
+                                                              check.names = FALSE, # can't have check.names = FALSE
+                                                              stringsAsFactors = TRUE))
 
     partial <- missing == "Use partial data"
 

--- a/tests/testthat/test-estimationdata.R
+++ b/tests/testthat/test-estimationdata.R
@@ -71,12 +71,15 @@ missing.level.test <- data.frame(Y = factor(c(1, 2, 2, 3, 3), labels = LETTERS[1
                                  X1 = c(NA, 1, NA, 3, 4),
                                  X2 = c(NA, 1, 2, 3, 4),
                                  X3 = c(NA, 3, 2, 1, 4))
-expected.dummy.missing.level <- data.frame(Y = factor(c(2, 2, 3, 3), labels = LETTERS[2:3]),
-                                           X1 = c(1, 8/3, 3, 4),
-                                           X2 = c(1, 2, 3, 4),
-                                           X3 = c(3, 2, 1, 4),
-                                           X1.dummy.var_GQ9KqD7YOf = c(0, 1, 0, 0),
-                                           row.names = 2:5)
+expected.dummy.missing.level <- structure(list(Y = structure(c(1L, 1L, 2L, 2L),
+                                                             .Label = c("B", "C"),
+                                                             class = "factor"),
+                                               X1 = c(1, 2.66666666666667, 3, 4),
+                                               X2 = c(1, 2, 3, 4),
+                                               X3 = c(3, 2, 1, 4),
+                                               X1.dummy.var_GQ9KqD7YOf = structure(c(0L, 1L, 0L, 0L),
+                                                                                   predictors.matching.dummy = "X1")),
+                                          row.names = 2:5, class = "data.frame")
 no.level.test <- data.frame(Y  = c(1, 2, 2, 3, 3),
                             X1 = c(NA, 1, NA, 3, 4),
                             X2 = c(NA, 1, 2, 3, 4),

--- a/tests/testthat/test-get.R
+++ b/tests/testthat/test-get.R
@@ -74,3 +74,12 @@ test_that("GetData missing variable",
               expect_error(GetData(c ~ ., data = x), "Variable.")
 
           })
+
+test_that("DS-2986: Dummy variables compatible with DataFormula", {
+    expect_equal(DataFormula(`Profit Estimation.sav`$Variables$q1 ~ `Profit Estimation.sav`$Variables$q11 +
+                                 `Profit Estimation.sav`$Variables$q1.dummy.var_GQ9KqD7YOf +
+                                 `Profit Estimation.sav`$Variables$q11.dummy.var_GQ9KqD7YOf),
+                 `\`Profit Estimation.sav\`$Variables$q1` ~ `\`Profit Estimation.sav\`$Variables$q11` +
+                     `\`Profit Estimation.sav\`$Variables$q1.dummy.var_GQ9KqD7YOf` +
+                     `\`Profit Estimation.sav\`$Variables$q11.dummy.var_GQ9KqD7YOf`)
+})

--- a/tests/testthat/test-missingdata.R
+++ b/tests/testthat/test-missingdata.R
@@ -37,18 +37,21 @@ expected.missing.outcome.unchecked <- data.frame(Y = c(NA, 1), X1 = c(1, 2), X2 
 
 single.pred.missing <- data.frame(Y = 1:2, X1 = c(NA, 2), X2 = c(1, 2))
 expected.single <- data.frame(Y = 1:2, X1 = c(2, 2), X2 = c(1, 2), X1.dummy.var_GQ9KqD7YOf = c(1, 0))
-
+attr(expected.single[["X1.dummy.var_GQ9KqD7YOf"]], "predictors.matching.dummy") <- "X1"
 diag.missing <- data.frame(Y = 1:2, X1 = c(NA, 2), X2 = c(1, NA))
 diag.missing.dummy <- data.frame(Y = 1:2, X1 = c(2, 2), X2 = c(1, 1), X1.dummy.var_GQ9KqD7YOf = 1:0, X2.dummy.var_GQ9KqD7YOf = 0:1)
+attr(diag.missing.dummy[["X1.dummy.var_GQ9KqD7YOf"]], "predictors.matching.dummy") <- "X1"
+attr(diag.missing.dummy[["X2.dummy.var_GQ9KqD7YOf"]], "predictors.matching.dummy") <- "X2"
 
 missing.predictors.case.df <- data.frame(Y = 1:3, X1 = c(NA, 1, 2), X2 = c(NA, -1, 0))
 expected.missing.predictors <- structure(list(Y = 2:3, X1 = c(1, 2), X2 = c(-1, 0)),
                                          row.names = 2:3, class = "data.frame")
+
 expected.missing.predictors.unchecked <- structure(list(Y = 1:3,
                                                         X1 = c(1.5, 1, 2),
                                                         X2 = c(-0.5, -1, 0),
-                                                        X1.dummy.var_GQ9KqD7YOf = c(1L, 0L, 0L),
-                                                        X2.dummy.var_GQ9KqD7YOf = c(1L, 0L, 0L)),
+                                                        X1.dummy.var_GQ9KqD7YOf = structure(c(1L, 0L, 0L),
+                                                                                            predictors.matching.dummy = c("X1", "X2"))),
                                                    class = "data.frame", row.names = c(NA, -3L))
 
 larger.case.with.missing.df <- data.frame(Y  = c(1, 2,  3,  4, 5, NA, 1, 2,  1),
@@ -57,14 +60,17 @@ larger.case.with.missing.df <- data.frame(Y  = c(1, 2,  3,  4, 5, NA, 1, 2,  1),
 expected.larger.case <- structure(list(Y = c(1, 2, 3, 4, 5, 1, 2),
                                        X1 = c(1, 4, 2, 3, 2, 1, 0),
                                        X2 = c(5, 4, 6, 3.28571428571429, 1, 4, 0),
-                                       X1.dummy.var_GQ9KqD7YOf = c(0L, 0L, 1L, 0L, 0L, 0L, 0L),
-                                       X2.dummy.var_GQ9KqD7YOf = c(0L, 0L, 0L, 1L, 0L, 0L, 0L)),
+                                       X1.dummy.var_GQ9KqD7YOf = structure(c(0L,0L, 1L, 0L, 0L, 0L, 0L),
+                                                                           predictors.matching.dummy = "X1"),
+                                       X2.dummy.var_GQ9KqD7YOf = structure(c(0L, 0L, 0L, 1L, 0L, 0L, 0L),
+                                                                           predictors.matching.dummy = "X2")),
                                   row.names = c(1L, 2L, 3L, 4L, 5L, 7L, 8L), class = "data.frame")
 
 factor.in.df <- data.frame(Y = 1:3, X1 = factor(1:3, labels = LETTERS[1:3]), X2 = 1:3)
 missing.factor.in.df <- data.frame(Y = 1:3, X1 = factor(c(NA, 2:3), labels = LETTERS[2:3]), X2 = 1:3)
 expected.missing.factor <- data.frame(Y = 1:3, X1 = factor(c(2, 2:3), labels = LETTERS[2:3]), X2 = 1:3,
                                       X1.dummy.var_GQ9KqD7YOf = c(1, 0, 0))
+attr(expected.missing.factor[["X1.dummy.var_GQ9KqD7YOf"]], "predictors.matching.dummy") <- "X1"
 df.with.text <- data.frame(Y = 1:2, X1 = 1:2, X3 = c(NA, LETTERS[1]),
                            stringsAsFactors = FALSE)
 edge.case <- data.frame(Y = 1:5, X = 1:5)
@@ -72,6 +78,7 @@ edge.case <- data.frame(Y = 1:5, X = 1:5)
 expected.edge.with.missing <- structure(list(Y = 1:5, X = c(4.5, 4.5, 4.5, 4, 5),
                                              X.dummy.var_GQ9KqD7YOf = c(1L, 1L, 1L, 0L, 0L)),
                                         class = "data.frame", row.names = c(NA, -5L))
+attr(expected.edge.with.missing[["X.dummy.var_GQ9KqD7YOf"]], "predictors.matching.dummy") <- "X"
 
 test_that("Dummy variable adjustment", {
     expect_identical(AddDummyVariablesForNAs(no.missing.df, outcome.name = "Y"),
@@ -114,4 +121,35 @@ test_that("Dummy variable adjustment", {
     edge.case[1:3, 2] <- NA
     expect_identical(AddDummyVariablesForNAs(edge.case, outcome.name = "Y"),
                      expected.edge.with.missing)
+})
+
+
+test_that("DS-2986: Check aliased dummy variables reduced and mapping retained", {
+    aliased.missing <- data.frame(Y = 1:2, X1 = c(NA, 2), X2 = c(NA, 3), X3 = c(1:2))
+    exp.aliased.missing <- data.frame(Y = 1:2, X1 = c(2, 2), X2 = c(3, 3), X3 = 1:2,
+                                      X1.dummy.var_GQ9KqD7YOf = c(1, 0))
+    attr(exp.aliased.missing[["X1.dummy.var_GQ9KqD7YOf"]], "predictors.matching.dummy") <- paste0("X", 1:2)
+    expect_equal(AddDummyVariablesForNAs(aliased.missing, outcome.name = "Y"),
+                 exp.aliased.missing)
+    multi.aliased.missing <- data.frame(Y = 1:2, X1 = c(NA, 2), X2 = c(NA, 3), X3 = c(1:2),
+                                        X4 = c(1, NA), X5 = 3:4, X6 = c(2, NA))
+    exp.multi.missing <- data.frame(Y = 1:2, X1 = c(2, 2), X2 = c(3, 3), X3 = 1:2,
+                                    X4 = c(1, 1), X5 = c(3, 4), X6 = c(2, 2),
+                                    X1.dummy.var_GQ9KqD7YOf = c(1, 0),
+                                    X4.dummy.var_GQ9KqD7YOf = c(0, 1))
+    attr(exp.multi.missing[["X1.dummy.var_GQ9KqD7YOf"]], "predictors.matching.dummy") <- paste0("X", 1:2)
+    attr(exp.multi.missing[["X4.dummy.var_GQ9KqD7YOf"]], "predictors.matching.dummy") <- paste0("X", c(4, 6))
+    expect_equal(AddDummyVariablesForNAs(multi.aliased.missing, outcome.name = "Y"),
+                 exp.multi.missing)
+    # Attributes retained when filtering
+    multi.aliased.missing <- data.frame(Y = 1:3, X1 = c(NA, 2, NA), X2 = c(NA, 3, NA), X3 = c(1:2, NA),
+                                        X4 = c(1, NA, NA), X5 = c(3:4, NA), X6 = c(2, NA, NA))
+    exp.multi.missing <- data.frame(Y = 1:2, X1 = c(2, 2), X2 = c(3, 3), X3 = 1:2,
+                                    X4 = c(1, 1), X5 = c(3, 4), X6 = c(2, 2),
+                                    X1.dummy.var_GQ9KqD7YOf = c(1, 0),
+                                    X4.dummy.var_GQ9KqD7YOf = c(0, 1))
+    attr(exp.multi.missing[["X1.dummy.var_GQ9KqD7YOf"]], "predictors.matching.dummy") <- paste0("X", 1:2)
+    attr(exp.multi.missing[["X4.dummy.var_GQ9KqD7YOf"]], "predictors.matching.dummy") <- paste0("X", c(4, 6))
+    expect_equal(AddDummyVariablesForNAs(multi.aliased.missing, outcome.name = "Y"),
+                 exp.multi.missing)
 })

--- a/tests/testthat/test-missingdata.R
+++ b/tests/testthat/test-missingdata.R
@@ -152,4 +152,14 @@ test_that("DS-2986: Check aliased dummy variables reduced and mapping retained",
     attr(exp.multi.missing[["X4.dummy.var_GQ9KqD7YOf"]], "predictors.matching.dummy") <- paste0("X", c(4, 6))
     expect_equal(AddDummyVariablesForNAs(multi.aliased.missing, outcome.name = "Y"),
                  exp.multi.missing)
+    names(aliased.missing) <- paste0("data$Questions$", names(aliased.missing))
+    exp.aliased.missing <- structure(list(`data$Questions$Y` = 1:2,
+                                          `data$Questions$X1` = c(2, 2),
+                                          `data$Questions$X2` = c(3, 3),
+                                          `data$Questions$X3` = c(1, 2),
+                                          `data$Questions$X1.dummy.var_GQ9KqD7YOf` =
+                                              structure(1:0, predictors.matching.dummy = c("data$Questions$X1", "data$Questions$X2"))),
+                                     row.names = c(NA, -2L), class = "data.frame")
+    expect_equal(AddDummyVariablesForNAs(aliased.missing, outcome.name = "data$Questions$Y"),
+                 exp.aliased.missing)
 })


### PR DESCRIPTION
Identify and deduplicate dummy variables created in the Dummy 
variable adjustment missing value method. Duplicates are created 
when variables have the exactly the same cases with missing values.
Also adds attribute to each dummy variable pointing to the variable 
names that it is associated with.

- DS-2986 Duplicate cols handled in Dummy adjustment
- DS-2986 Add/update  unit tests for dummy aliasing
- DS-2986 Update data.frame to use pre 4.0.0 argument
- DS-2986 Update estimation data tests
