### PR TITLE
DS-2988 Improve DataFormula

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Imports: CVXR (>= 1.0.0),
  stats,
  stringr,
  survey
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 Encoding: UTF-8
 Suggests: foreign,
  testthat,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipData
 Type: Package
 Title: Functions for extracting and describing data
-Version: 1.2.13
+Version: 1.2.14
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Functions for extracting data from formulas and

--- a/R/get.R
+++ b/R/get.R
@@ -72,7 +72,7 @@ DataFormula <- function(formula, data = NULL)
     .inDatasetOrUsesBackTicks <- function(x)
         indexOfUnescapedCharacter(x, char = "$") > -1 || grepl("`", x)
     var.names.flagged <- vapply(as.list(var.names), .inDatasetOrUsesBackTicks, logical(1))
-    dummy.vars.found <- grepl(".dummy.var_GQ9KqD7YOf$", var.names)
+    dummy.vars.found <- grepl("\\.dummy\\.var_GQ9KqD7YOf$", var.names)
     dummy.vars.dataset.referral <- dummy.vars.found & var.names.flagged
     if (dummy.vars.exist <- any(dummy.vars.dataset.referral))
     { # Extract the dummy variables from var.names and formula.str, handle each separately

--- a/R/get.R
+++ b/R/get.R
@@ -80,7 +80,9 @@ DataFormula <- function(formula, data = NULL)
         dummy.vars <- var.names[dummy.vars.dataset.referral]
         var.names <- var.names[!dummy.vars.dataset.referral]
         # Temporarily remove dummy variables from formula.str
-        dummy.vars.patt <- sub(patt = ".dummy.var_GQ9KqD7YOf", "\\.dummy\\.var_GQ9KqD7YOf", dummy.vars, fixed = TRUE)
+        dummy.vars.patt <- sub(pattern = ".dummy.var_GQ9KqD7YOf",
+                               replacement = "\\.dummy\\.var_GQ9KqD7YOf",
+                               dummy.vars, fixed = TRUE)
         patt <- paste0("?\\s\\+\\s*", gsub("$", "\\$", dummy.vars.patt, fixed = TRUE), collapse = "|")
         formula.str <- gsub(patt, "", formula.str)
     }

--- a/R/get.R
+++ b/R/get.R
@@ -79,7 +79,8 @@ DataFormula <- function(formula, data = NULL)
         dummy.vars <- var.names[dummy.vars.dataset.referral]
         var.names <- var.names[!dummy.vars.dataset.referral]
         # Temporarily remove dummy variables from formula.str
-        patt <- paste0("?\\s\\+\\s*", gsub("$", "\\$", dummy.vars, fixed = TRUE), collapse = "|")
+        dummy.vars.patt <- sub(patt = ".dummy.var_GQ9KqD7YOf", "\\.dummy\\.var_GQ9KqD7YOf", dummy.vars, fixed = TRUE)
+        patt <- paste0("?\\s\\+\\s*", gsub("$", "\\$", dummy.vars.patt, fixed = TRUE), collapse = "|")
         formula.str <- gsub(patt, "", formula.str)
     }
     # We sort names from longest to shortest since we will be substituting by name
@@ -96,7 +97,7 @@ DataFormula <- function(formula, data = NULL)
     }
     # Add dummy variables at the end, applying the same conditions, wrapping in backticks and
     # escaping existing backticks if necessary
-    if (any(dummy.vars.exist))
+    if (dummy.vars.exist)
     {
         dummy.vars <- paste0("`", gsub("`", "\\`", dummy.vars, fixed = TRUE), "`")
         formula.str <- paste0(formula.str, " + ", paste0(dummy.vars, collapse = " + "))

--- a/R/get.R
+++ b/R/get.R
@@ -98,13 +98,13 @@ DataFormula <- function(formula, data = NULL)
             { # Split by the $ character being careful not to split if there is a $ inside the data or
               # or variable/question names
                 split.names <- strsplit(name, r"(\$(?=([^`]*`[^`]*`)*[^`]*$))", perl = TRUE)[[1]]
-                # Escape the $ for the final gsub matching pattern below
+                # Escape the $ for the final sub matching pattern below
                 name <- paste0(split.names, collapse = "\\$")
                 # Escape the backticks for the replacements
                 split.names[-2] <- gsub("`", "\\\\`", split.names[-2], fixed = TRUE)
                 new.name <- paste0("`", paste0(split.names, collapse = "$"), "`")
             } else
-                new.name <- paste0("`", name, "`")
+                new.name <- paste0("`", gsub("`", "\\\\`", name, fixed = TRUE), "`")
 
             formula.str <- sub(paste0(name, r"((?=[^`]*(?:`[^`]*`[^`]*)*$))"),
                                new.name, formula.str, perl = TRUE)

--- a/tests/testthat/test-get.R
+++ b/tests/testthat/test-get.R
@@ -136,4 +136,10 @@ test_that("DS-2988: Precise replacement when dataset references are used", {
                  `dat$Variables$xy` ~ `dat$Variables$x`)
     expect_equal(DataFormula(`some dat`$Variables$xy ~ `some other dat`$Variables$x),
                  `\`some dat\`$Variables$xy` ~ `\`some other dat\`$Variables$x`)
+    expect_equal(DataFormula(dat$Variables$`x one y` ~ dat$Variables$`x one`),
+                 `dat$Variables$\`x one y\`` ~ `dat$Variables$\`x one\``)
+    expect_equal(DataFormula(dat$Variables$`x one y` ~ x),
+                 `dat$Variables$\`x one y\`` ~ x)
+    expect_equal(DataFormula(dat$Variables$`x one y` ~ `x one y`),
+                 `dat$Variables$\`x one y\`` ~ `\`x one y\``)
 })

--- a/tests/testthat/test-get.R
+++ b/tests/testthat/test-get.R
@@ -130,3 +130,10 @@ test_that("CleanBackticks: factors with non-integer levels; DS-2884",
     expect_true(all(grepl("^`", out)))
     expect_true(all(grepl(".sav`$Variables", out, fixed = TRUE)))
 })
+
+test_that("DS-2988: Precise replacement when dataset references are used", {
+    expect_equal(DataFormula(dat$Variables$xy ~ dat$Variables$x),
+                 `dat$Variables$xy` ~ `dat$Variables$x`)
+    expect_equal(DataFormula(`some dat`$Variables$xy ~ `some other dat`$Variables$x),
+                 `\`some dat\`$Variables$xy` ~ `\`some other dat\`$Variables$x`)
+})


### PR DESCRIPTION
Use a more precise regex that will only replace formula elements a single 
element each time and not replace other matches that are subsets of
the current match

- DS-2988 Add stricter dummy variable check
- DS-2988 Simplify code for dummy vars
- DS-2988 Use more precise regex
- DS-2988 Version bump
- DS-2988 Correct partial matching argument [revdep skip]
- DS-2988 Reoxygenize docs [ci skip]
- DS-2988 Add more unit tests
