### PR TITLE
DS-4210: Sanitize variable names for SPSS files

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipData
 Type: Package
 Title: Functions for extracting and describing data
-Version: 1.6.6
+Version: 1.6.7
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Functions for extracting data from formulas and

--- a/R/mergedatasetsbycase.R
+++ b/R/mergedatasetsbycase.R
@@ -1762,23 +1762,14 @@ mergedVariableNames <- function(matched.names, use.names.and.labels.from)
     merged.names <- namesFromEarliestDataSet(matched.names,
                                              use.names.and.labels.from)
 
-    # Merged names may contain duplicate variable names due to the user
-    # specifying variables with the same name to not be combined or variables
-    # with the same name not being combined as their types are incompatible.
-    # Variables that only differ by case are also considered duplicate.
-    # We rename variables so that the names are unique.
-    dup <- which(duplicated(tolower(merged.names)))
-    renamed.variables <- matrix(nrow = length(dup), ncol = 2)
-    colnames(renamed.variables) <- c("Original name", "New name")
-    for (i in seq_along(dup))
-    {
-        new.name <- uniqueName(merged.names[dup[i]], merged.names, "_")
-        renamed.variables[i, ] <- c(merged.names[dup[i]], new.name)
-        merged.names[dup[i]] <- new.name
-    }
-    attr(merged.names, "renamed.variables") <- renamed.variables
+    # Rename duplicates and other forbidden SPSS names
+    new.names <- sanitizeSPSSVariableNames(merged.names)
+    renamed.variables <- cbind("Original name" = merged.names,
+                               "New name" = new.names)
+    renamed.variables <- renamed.variables[new.names != merged.names, , drop = FALSE]
+    attr(new.names, "renamed.variables") <- renamed.variables
 
-    merged.names
+    new.names
 }
 
 # Get the names from the earliest data set for each row in matched.names

--- a/R/mergedatasetsbyvariable.R
+++ b/R/mergedatasetsbyvariable.R
@@ -431,7 +431,7 @@ mergedDataSetVariableNames <- function(input.data.sets.metadata,
         for (nm in included.variable.names.list[[i]])
             merged.data.set.var.names <- c(merged.data.set.var.names,
                                            uniqueName(nm, merged.data.set.var.names, delimiter = "_"))
-
+    merged.data.set.var.names <- sanitizeSPSSVariableNames(merged.data.set.var.names)
     attr(merged.data.set.var.names, "included.variable.names.list") <- included.variable.names.list
     attr(merged.data.set.var.names, "omitted.variable.names.list") <- omitted.var.names.list
 

--- a/R/mergingandstackingutilities.R
+++ b/R/mergingandstackingutilities.R
@@ -532,8 +532,6 @@ sanitizeSPSSVariableNames <- function(variable.names) {
     dupes <- duplicated(tolower(variable.names))
     if (any(dupes)) {
         dupe.ind <- which(dupes)
-        warning("Some variable names were duplicated after cleaning and have been renamed: ",
-                paste0(unique(variable.names[dupes]), collapse = ", "))
         for (i in dupe.ind) {
             variable.names[i] <- uniqueName(variable.names[i],
                                             existing.names = variable.names,

--- a/R/mergingandstackingutilities.R
+++ b/R/mergingandstackingutilities.R
@@ -76,7 +76,6 @@ createReadErrorHandler <- function(data.set.name)
 #' @importFrom flipAPI QSaveData IsDisplayrCloudDriveAvailable
 writeDataSet <- function(data.set, data.set.name, is.saved.to.cloud)
 {
-    data.set <- sanitizeSPSSVariableNames(data.set)
     if (is.saved.to.cloud)
         QSaveData(data.set, data.set.name)
     else
@@ -495,8 +494,7 @@ parseVariableWildcardForMerging <- function(wildcard.text, variable.names,
 # Set to 2GB as I found that memory issues start to occur beyond here
 DATA.SET.SIZE.LIMIT <- 2 * 1e9
 
-sanitizeSPSSVariableNames <- function(merged.data.file) {
-    variable.names <- colnames(merged.data.file)
+sanitizeSPSSVariableNames <- function(variable.names) {
     # Can't begin with or end with a period
     forbidden.period <- startsWith(variable.names, ".")
     if (any(forbidden.period)) {
@@ -543,8 +541,7 @@ sanitizeSPSSVariableNames <- function(merged.data.file) {
         }
     }
 
-    colnames(merged.data.file) <- variable.names
-    merged.data.file
+    variable.names
 }
 
 
@@ -553,7 +550,7 @@ addSuffixFittingByteLimit <- function(string, suffix = "", byte.limit = 64) {
     size <- nchar(new.string, type = "bytes")
 
     # Nothing to do here, return
-    if (size < byte.limit)
+    if (size <= byte.limit)
         return (new.string)
 
     # Easy encoding, just truncate and paste

--- a/R/stacking.R
+++ b/R/stacking.R
@@ -1177,7 +1177,9 @@ stackedDataSet <- function(input.data.set, input.data.set.metadata,
                                      names(stacked.data.set))]] <- observation
     }
 
-    data.frame(stacked.data.set, check.names = FALSE)
+    stacked.data.set <- data.frame(stacked.data.set, check.names = FALSE)
+    colnames(stacked.data.set) <- sanitizeSPSSVariableNames(colnames(stacked.data.set))
+    stacked.data.set
 }
 
 stackedVariableName <- function(group.ind, input.variable.names, taken.names)

--- a/tests/testthat/test-mergedatasetsbycase.R
+++ b/tests/testthat/test-mergedatasetsbycase.R
@@ -115,20 +115,21 @@ test_that("Automatically determine match", {
 })
 
 test_that("Matching by variable labels", {
-    result <- MergeDataSetsByCase(data.set.names = c(findInstDirFile("cola1.sav"),
+    expect_warning(result <- MergeDataSetsByCase(data.set.names = c(findInstDirFile("cola1.sav"),
                                                      findInstDirFile("cola7.sav"),
                                                      findInstDirFile("cola8.sav")),
                                   auto.select.what.to.match.by = FALSE,
                                   match.by.variable.names = FALSE,
                                   match.by.variable.labels = TRUE,
                                   match.by.value.labels = FALSE,
-                                  include.merged.data.set.in.output = TRUE)
+                                  include.merged.data.set.in.output = TRUE),
+                   "Some variable names were duplicated after cleaning and have been renamed:")
     # Q1_F_c matched despite variable names being different
     expect_true(all(!is.na(result$merged.data.set$Q1_F_c)))
 })
 
 test_that("Matching by value labels", {
-    result <- MergeDataSetsByCase(data.set.names = c(findInstDirFile("cola1.sav"),
+    expect_warning(result <- MergeDataSetsByCase(data.set.names = c(findInstDirFile("cola1.sav"),
                                                      findInstDirFile("cola7.sav"),
                                                      findInstDirFile("cola8.sav")),
                                   auto.select.what.to.match.by = FALSE,
@@ -136,7 +137,8 @@ test_that("Matching by value labels", {
                                   match.by.variable.labels = FALSE,
                                   match.by.value.labels = TRUE,
                                   include.merged.data.set.in.output = TRUE,
-                                  variables.to.omit = "Q1_E_c1-Q1_B_c1")
+                                  variables.to.omit = "Q1_E_c1-Q1_B_c1"),
+                   "Some variable names were duplicated after cleaning and have been renamed:")
     # Q1_F_c matched despite variable names being different
     expect_true(all(!is.na(result$merged.data.set$Q1_F_c)))
 })
@@ -164,14 +166,15 @@ test_that("Ignore non-alphanumeric characters when matching", {
 })
 
 test_that("Minimum match percentage", {
-    result <- MergeDataSetsByCase(data.set.names = c(findInstDirFile("cola10.sav"),
+    expect_warning(result <- MergeDataSetsByCase(data.set.names = c(findInstDirFile("cola10.sav"),
                                                      findInstDirFile("cola12.sav")),
                                   auto.select.what.to.match.by = FALSE,
                                   match.by.variable.names = FALSE,
                                   match.by.variable.labels = TRUE,
                                   match.by.value.labels = FALSE,
                                   min.match.percentage = 90,
-                                  include.merged.data.set.in.output = TRUE)
+                                  include.merged.data.set.in.output = TRUE),
+                   "Some variable names were duplicated after cleaning and have been renamed:")
     # Q4_A_3 not merged together since "Coke" differs from "Coca Cola" beyond
     # the min match percentage
     expect_true("Q4_A_3_1" %in% names(result$merged.data.set))
@@ -241,11 +244,12 @@ test_that("Manually combine variables by specifying names of variables to combin
 })
 
 test_that("Manually combine variables by specifying names of variables (with data set index) to combine", {
-    result <- MergeDataSetsByCase(data.set.names = c(findInstDirFile("cola1.sav"),
+    expect_warning(result <- MergeDataSetsByCase(data.set.names = c(findInstDirFile("cola1.sav"),
                                                      findInstDirFile("cola2.sav"),
                                                      findInstDirFile("cola4.sav")),
                                            include.merged.data.set.in.output = TRUE,
-                                           variables.to.combine = "Q3_3_new_name(3),Q3_3(2)")
+                                           variables.to.combine = "Q3_3_new_name(3),Q3_3(2)"),
+                   "Some variable names were duplicated after cleaning and have been renamed:")
     merged.data.set <- result$merged.data.set
     expect_true("Q3_3" %in% names(merged.data.set))
     # new variable created with Q3_3 from data set 1 since only Q3_3 from
@@ -362,10 +366,11 @@ test_that("Error when two variables to be combined are found in the same data se
 })
 
 test_that("Variables to not combine", {
-    result <- MergeDataSetsByCase(data.set.names = c(findInstDirFile("cola1.sav"),
+    expect_warning(result <- MergeDataSetsByCase(data.set.names = c(findInstDirFile("cola1.sav"),
                                                      findInstDirFile("cola2.sav"),
                                                      findInstDirFile("cola3.sav")),
-                                  variables.to.not.combine = "Q3")
+                                  variables.to.not.combine = "Q3"),
+                   "Some variable names were duplicated after cleaning and have been renamed:")
     expect_true(all(c("Q3", "Q3_1", "Q3_2") %in% result$merged.data.set.metadata$variable.names))
 })
 
@@ -456,11 +461,12 @@ test_that("Variable type conversion (text to date)", {
 })
 
 test_that("Non-combinable variables", {
-    result <- MergeDataSetsByCase(data.set.names = c(findInstDirFile("cola3.sav"),
+    expect_warning(result <- MergeDataSetsByCase(data.set.names = c(findInstDirFile("cola3.sav"),
                                                      findInstDirFile("cola7.sav")),
                                   match.by.variable.names = TRUE,
                                   match.by.variable.labels = FALSE,
-                                  match.by.value.labels = FALSE)
+                                  match.by.value.labels = FALSE),
+                   "Some variable names were duplicated after cleaning and have been renamed:")
     # Q3_3 in the two datasets cannot be combined as the latter is a text
     # variable with many different values. So a new variable Q3_3_1 is created
     # immediately below Q3_3
@@ -1077,7 +1083,7 @@ test_that("mergedVariableNames (preferring first data set)", {
                                         use.names.and.labels.from = "First data set")
     expect_equal(merged.names,
                  structure(c("Q1", "Q2", "Q3"),
-                           renamed.variables = structure(logical(0), .Dim = c(0L, 2L),
+                           renamed.variables = structure(character(0), .Dim = c(0L, 2L),
                                                          .Dimnames = list(NULL, c("Original name", "New name")))))
 })
 
@@ -1088,7 +1094,7 @@ test_that("mergedVariableNames (preferring last data set)", {
                                         use.names.and.labels.from = "Last data set")
     expect_equal(merged.names,
                  structure(c("Q1B", "Q2", "Q3B"),
-                           renamed.variables = structure(logical(0), .Dim = c(0L, 2L),
+                           renamed.variables = structure(character(0), .Dim = c(0L, 2L),
                                                          .Dimnames = list(NULL, c("Original name", "New name")))))
 })
 
@@ -1096,8 +1102,9 @@ test_that("mergedVariableNames (variable renamed due to name conflict)", {
     # Q1 appears in 2 rows so the second one gets renamed
     matched.names <- matrix(c("Q1", NA_character_, NA_character_, "Q3",
                               NA_character_, "Q1", "Q2", "Q3B"), ncol = 2)
-    merged.names <- mergedVariableNames(matched.names = matched.names,
-                                        use.names.and.labels.from = "First data set")
+    expect_warning(merged.names <- mergedVariableNames(matched.names = matched.names,
+                                        use.names.and.labels.from = "First data set"),
+                   "Some variable names were duplicated after cleaning and have been renamed:")
     expect_equal(merged.names,
                  structure(c("Q1", "Q1_1", "Q2", "Q3"),
                            renamed.variables = structure(c("Q1", "Q1_1"), .Dim = 1:2,

--- a/tests/testthat/test-mergedatasetsbycase.R
+++ b/tests/testthat/test-mergedatasetsbycase.R
@@ -115,21 +115,20 @@ test_that("Automatically determine match", {
 })
 
 test_that("Matching by variable labels", {
-    expect_warning(result <- MergeDataSetsByCase(data.set.names = c(findInstDirFile("cola1.sav"),
+    result <- MergeDataSetsByCase(data.set.names = c(findInstDirFile("cola1.sav"),
                                                      findInstDirFile("cola7.sav"),
                                                      findInstDirFile("cola8.sav")),
                                   auto.select.what.to.match.by = FALSE,
                                   match.by.variable.names = FALSE,
                                   match.by.variable.labels = TRUE,
                                   match.by.value.labels = FALSE,
-                                  include.merged.data.set.in.output = TRUE),
-                   "Some variable names were duplicated after cleaning and have been renamed:")
+                                  include.merged.data.set.in.output = TRUE)
     # Q1_F_c matched despite variable names being different
     expect_true(all(!is.na(result$merged.data.set$Q1_F_c)))
 })
 
 test_that("Matching by value labels", {
-    expect_warning(result <- MergeDataSetsByCase(data.set.names = c(findInstDirFile("cola1.sav"),
+    result <- MergeDataSetsByCase(data.set.names = c(findInstDirFile("cola1.sav"),
                                                      findInstDirFile("cola7.sav"),
                                                      findInstDirFile("cola8.sav")),
                                   auto.select.what.to.match.by = FALSE,
@@ -137,8 +136,7 @@ test_that("Matching by value labels", {
                                   match.by.variable.labels = FALSE,
                                   match.by.value.labels = TRUE,
                                   include.merged.data.set.in.output = TRUE,
-                                  variables.to.omit = "Q1_E_c1-Q1_B_c1"),
-                   "Some variable names were duplicated after cleaning and have been renamed:")
+                                  variables.to.omit = "Q1_E_c1-Q1_B_c1")
     # Q1_F_c matched despite variable names being different
     expect_true(all(!is.na(result$merged.data.set$Q1_F_c)))
 })
@@ -166,15 +164,14 @@ test_that("Ignore non-alphanumeric characters when matching", {
 })
 
 test_that("Minimum match percentage", {
-    expect_warning(result <- MergeDataSetsByCase(data.set.names = c(findInstDirFile("cola10.sav"),
+    result <- MergeDataSetsByCase(data.set.names = c(findInstDirFile("cola10.sav"),
                                                      findInstDirFile("cola12.sav")),
                                   auto.select.what.to.match.by = FALSE,
                                   match.by.variable.names = FALSE,
                                   match.by.variable.labels = TRUE,
                                   match.by.value.labels = FALSE,
                                   min.match.percentage = 90,
-                                  include.merged.data.set.in.output = TRUE),
-                   "Some variable names were duplicated after cleaning and have been renamed:")
+                                  include.merged.data.set.in.output = TRUE)
     # Q4_A_3 not merged together since "Coke" differs from "Coca Cola" beyond
     # the min match percentage
     expect_true("Q4_A_3_1" %in% names(result$merged.data.set))
@@ -244,12 +241,11 @@ test_that("Manually combine variables by specifying names of variables to combin
 })
 
 test_that("Manually combine variables by specifying names of variables (with data set index) to combine", {
-    expect_warning(result <- MergeDataSetsByCase(data.set.names = c(findInstDirFile("cola1.sav"),
+    result <- MergeDataSetsByCase(data.set.names = c(findInstDirFile("cola1.sav"),
                                                      findInstDirFile("cola2.sav"),
                                                      findInstDirFile("cola4.sav")),
-                                           include.merged.data.set.in.output = TRUE,
-                                           variables.to.combine = "Q3_3_new_name(3),Q3_3(2)"),
-                   "Some variable names were duplicated after cleaning and have been renamed:")
+                                  include.merged.data.set.in.output = TRUE,
+                                  variables.to.combine = "Q3_3_new_name(3),Q3_3(2)")
     merged.data.set <- result$merged.data.set
     expect_true("Q3_3" %in% names(merged.data.set))
     # new variable created with Q3_3 from data set 1 since only Q3_3 from
@@ -366,11 +362,10 @@ test_that("Error when two variables to be combined are found in the same data se
 })
 
 test_that("Variables to not combine", {
-    expect_warning(result <- MergeDataSetsByCase(data.set.names = c(findInstDirFile("cola1.sav"),
+    result <- MergeDataSetsByCase(data.set.names = c(findInstDirFile("cola1.sav"),
                                                      findInstDirFile("cola2.sav"),
                                                      findInstDirFile("cola3.sav")),
-                                  variables.to.not.combine = "Q3"),
-                   "Some variable names were duplicated after cleaning and have been renamed:")
+                                  variables.to.not.combine = "Q3")
     expect_true(all(c("Q3", "Q3_1", "Q3_2") %in% result$merged.data.set.metadata$variable.names))
 })
 
@@ -461,12 +456,11 @@ test_that("Variable type conversion (text to date)", {
 })
 
 test_that("Non-combinable variables", {
-    expect_warning(result <- MergeDataSetsByCase(data.set.names = c(findInstDirFile("cola3.sav"),
+    result <- MergeDataSetsByCase(data.set.names = c(findInstDirFile("cola3.sav"),
                                                      findInstDirFile("cola7.sav")),
                                   match.by.variable.names = TRUE,
                                   match.by.variable.labels = FALSE,
-                                  match.by.value.labels = FALSE),
-                   "Some variable names were duplicated after cleaning and have been renamed:")
+                                  match.by.value.labels = FALSE)
     # Q3_3 in the two datasets cannot be combined as the latter is a text
     # variable with many different values. So a new variable Q3_3_1 is created
     # immediately below Q3_3
@@ -1102,9 +1096,8 @@ test_that("mergedVariableNames (variable renamed due to name conflict)", {
     # Q1 appears in 2 rows so the second one gets renamed
     matched.names <- matrix(c("Q1", NA_character_, NA_character_, "Q3",
                               NA_character_, "Q1", "Q2", "Q3B"), ncol = 2)
-    expect_warning(merged.names <- mergedVariableNames(matched.names = matched.names,
-                                        use.names.and.labels.from = "First data set"),
-                   "Some variable names were duplicated after cleaning and have been renamed:")
+    merged.names <- mergedVariableNames(matched.names = matched.names,
+                                        use.names.and.labels.from = "First data set")
     expect_equal(merged.names,
                  structure(c("Q1", "Q1_1", "Q2", "Q3"),
                            renamed.variables = structure(c("Q1", "Q1_1"), .Dim = 1:2,

--- a/tests/testthat/test-mergingandstackingutilities.R
+++ b/tests/testthat/test-mergingandstackingutilities.R
@@ -121,3 +121,57 @@ test_that("readDataSets: better error message when data file is invalid", {
                  paste0("The data file 'bad.sav' could not be parsed. ",
                         "The data file may be fixed by inserting it in a Displayr document, exporting it as an SPSS file \\(.sav\\) via the Publish button, and then uploading it back to the cloud drive."))
 })
+
+test_that("DS-4210: SPSS variable names sanitized before attempting to save", {
+
+    makeDummyData <- function(var.names) {
+        dummy.data = as.data.frame(matrix(0, nrow = 5, ncol = length(var.names)))
+        colnames(dummy.data) <- var.names
+        dummy.data
+    }
+
+    # Period at beginning
+    dummy <- makeDummyData(c(".A", ".B", ".C"))
+    expect_warning(z <- sanitizeSPSSVariableNames(dummy),
+                   "Cannot save variables names which begin with '.'")
+    expect_equal(colnames(z), c("A", "B", "C"))
+
+    # Period at end
+    dummy <- makeDummyData(c("A.", "B.", "C."))
+    expect_warning(z <- sanitizeSPSSVariableNames(dummy),
+                   "Cannot save variables names which end with '.'")
+    expect_equal(colnames(z), c("A", "B", "C"))
+
+    # Restricted names
+    dummy <- makeDummyData(c("A", "B", "WITH"))
+    expect_warning(z <- sanitizeSPSSVariableNames(dummy),
+                   "Cannot save variables whose names are SPSS reserved keywords.")
+    expect_equal(colnames(z), c("A", "B", "WITH_r"))
+
+    # Too long
+    bad.strings = c('S2ShareofSalience_OtherpleasespecifyS2ShareofSalience_Otherpleasespecify',
+                    'S2ShareofSalience_Otherpleasespecify_0S2ShareofSalience_Otherpleasespecify_0',
+                    'L2LeisureActivitiesConsideration_OtherpleasespecifyL2LeisureActivitiesConsideration_Otherpleasespecify',
+                    'L2LeisureActivitiesConsideration_Otherpleasespecify_0L2LeisureActivitiesConsideration_Otherpleasespecify_0',
+                    'PQ4a_OtherwithchildrenathomepleasespecifyPQ4a_Otherwithchildrenathomepleasespecify')
+    dummy <- makeDummyData(bad.strings)
+    expect_warning(z <- sanitizeSPSSVariableNames(dummy),
+                   "Some variable names were too long and have been truncated: ")
+    expect_true(all(nchar(colnames(z), type = 'bytes') <= 64))
+
+    # Too long, not ascii
+    bad.strings = c("トム・クルーズが嫌いな理由を10語以内で教えてください",
+                    "春に訪れたい日本で一番好きな都市はどこですか")
+
+    dummy <- makeDummyData(bad.strings)
+    expect_warning(z <- sanitizeSPSSVariableNames(dummy),
+                   "Some variable names were too long and have been truncated: ")
+    expect_true(all(nchar(colnames(z), type = 'bytes') <= 64))
+
+
+    # Prevent duplicates
+    dummy <- makeDummyData(c("A", "B", "WITH", "A", "B", "WITH"))
+    expect_warning(z <- sanitizeSPSSVariableNames(dummy),
+                   "Some variable names were duplicated after cleaning and have been renamed:")
+    expect_equal(colnames(z), c("A", "B", "WITH_r", "A_1", "B_1", "WITH_r_1"))
+})

--- a/tests/testthat/test-mergingandstackingutilities.R
+++ b/tests/testthat/test-mergingandstackingutilities.R
@@ -164,6 +164,6 @@ test_that("DS-4210: SPSS variable names sanitized before attempting to save", {
     # Prevent duplicates
     bad.names <- c("A", "B", "WITH", "A", "B", "WITH")
     expect_warning(z <- sanitizeSPSSVariableNames(bad.names),
-                   "Some variable names were duplicated after cleaning and have been renamed:")
+                   "Cannot save variables whose names are SPSS reserved keywords")
     expect_equal(z, c("A", "B", "WITH_r", "A_1", "B_1", "WITH_r_1"))
 })

--- a/tests/testthat/test-mergingandstackingutilities.R
+++ b/tests/testthat/test-mergingandstackingutilities.R
@@ -124,54 +124,46 @@ test_that("readDataSets: better error message when data file is invalid", {
 
 test_that("DS-4210: SPSS variable names sanitized before attempting to save", {
 
-    makeDummyData <- function(var.names) {
-        dummy.data = as.data.frame(matrix(0, nrow = 5, ncol = length(var.names)))
-        colnames(dummy.data) <- var.names
-        dummy.data
-    }
-
     # Period at beginning
-    dummy <- makeDummyData(c(".A", ".B", ".C"))
-    expect_warning(z <- sanitizeSPSSVariableNames(dummy),
+    bad.names <- c(".A", ".B", ".C")
+    expect_warning(z <- sanitizeSPSSVariableNames(bad.names),
                    "Cannot save variables names which begin with '.'")
-    expect_equal(colnames(z), c("A", "B", "C"))
+    expect_equal(z, c("A", "B", "C"))
 
     # Period at end
-    dummy <- makeDummyData(c("A.", "B.", "C."))
-    expect_warning(z <- sanitizeSPSSVariableNames(dummy),
+    bad.names <- c("A.", "B.", "C.")
+    expect_warning(z <- sanitizeSPSSVariableNames(bad.names),
                    "Cannot save variables names which end with '.'")
-    expect_equal(colnames(z), c("A", "B", "C"))
+    expect_equal(z, c("A", "B", "C"))
 
     # Restricted names
-    dummy <- makeDummyData(c("A", "B", "WITH"))
-    expect_warning(z <- sanitizeSPSSVariableNames(dummy),
+    bad.names <- c("A", "B", "WITH")
+    expect_warning(z <- sanitizeSPSSVariableNames(bad.names),
                    "Cannot save variables whose names are SPSS reserved keywords.")
-    expect_equal(colnames(z), c("A", "B", "WITH_r"))
+    expect_equal(z, c("A", "B", "WITH_r"))
 
     # Too long
-    bad.strings = c('S2ShareofSalience_OtherpleasespecifyS2ShareofSalience_Otherpleasespecify',
+    bad.names <- c('S2ShareofSalience_OtherpleasespecifyS2ShareofSalience_Otherpleasespecify',
                     'S2ShareofSalience_Otherpleasespecify_0S2ShareofSalience_Otherpleasespecify_0',
                     'L2LeisureActivitiesConsideration_OtherpleasespecifyL2LeisureActivitiesConsideration_Otherpleasespecify',
                     'L2LeisureActivitiesConsideration_Otherpleasespecify_0L2LeisureActivitiesConsideration_Otherpleasespecify_0',
                     'PQ4a_OtherwithchildrenathomepleasespecifyPQ4a_Otherwithchildrenathomepleasespecify')
-    dummy <- makeDummyData(bad.strings)
-    expect_warning(z <- sanitizeSPSSVariableNames(dummy),
+    expect_warning(z <- sanitizeSPSSVariableNames(bad.names),
                    "Some variable names were too long and have been truncated: ")
-    expect_true(all(nchar(colnames(z), type = 'bytes') <= 64))
+    expect_true(all(nchar(z, type = 'bytes') <= 64))
 
     # Too long, not ascii
-    bad.strings = c("トム・クルーズが嫌いな理由を10語以内で教えてください",
+    bad.names <- c("トム・クルーズが嫌いな理由を10語以内で教えてください",
                     "春に訪れたい日本で一番好きな都市はどこですか")
 
-    dummy <- makeDummyData(bad.strings)
-    expect_warning(z <- sanitizeSPSSVariableNames(dummy),
+    expect_warning(z <- sanitizeSPSSVariableNames(bad.names),
                    "Some variable names were too long and have been truncated: ")
-    expect_true(all(nchar(colnames(z), type = 'bytes') <= 64))
+    expect_true(all(nchar(z, type = 'bytes') <= 64))
 
 
     # Prevent duplicates
-    dummy <- makeDummyData(c("A", "B", "WITH", "A", "B", "WITH"))
-    expect_warning(z <- sanitizeSPSSVariableNames(dummy),
+    bad.names <- c("A", "B", "WITH", "A", "B", "WITH")
+    expect_warning(z <- sanitizeSPSSVariableNames(bad.names),
                    "Some variable names were duplicated after cleaning and have been renamed:")
-    expect_equal(colnames(z), c("A", "B", "WITH_r", "A_1", "B_1", "WITH_r_1"))
+    expect_equal(z, c("A", "B", "WITH_r", "A_1", "B_1", "WITH_r_1"))
 })


### PR DESCRIPTION
Checks and fixes for:
* Periods at the start and end of names
* Names which are protected strings in SPSS
* Names which are longer than 64 bytes
* Duplicated names