### PR TITLE
DS-5306: Support data sets which already have mergesrc

### DIFF
--- a/R/mergedatasetsbycase.R
+++ b/R/mergedatasetsbycase.R
@@ -1936,9 +1936,16 @@ mergedDataSet <- function(data.sets, matched.names, merged.names,
     merged.data.set <- data.frame(merged.data.set, check.names = FALSE)
     names(merged.data.set) <- merged.names
 
-    merged.data.set[["mergesrc"]] <- mergeSrc(n.data.set.cases,
-                                              data.set.names = names(data.sets),
-                                              existing.mergesrc = merged.data.set$"mergesrc")
+    # Check whether we need to create a new mergesrc variable
+    sets.containing.mergesrc <- vapply(data.sets,
+                                       FUN = function (x) { !is.null(x[["mergesrc"]])},
+                                       FUN.VALUE = logical(1))
+    if (length(which(sets.containing.mergesrc)) < length(data.sets)) {
+        merged.data.set[["mergesrc"]] <- mergeSrc(n.data.set.cases,
+                                                  data.set.names = names(data.sets),
+                                                  existing.mergesrc = merged.data.set$"mergesrc")
+    }
+
     merged.data.set
 }
 
@@ -2585,7 +2592,6 @@ variableLabelFromDataSets <- function(matched.names.row, data.sets,
 # each variable came from.
 mergeSrc <- function(n.data.set.cases, data.set.names, existing.mergesrc = NULL)
 {
-
     n.data.sets <- length(n.data.set.cases)
     mergesrc <- rep(seq_len(n.data.sets), n.data.set.cases)
     attr(mergesrc, "labels") <- structure(seq_len(n.data.sets),

--- a/tests/testthat/test-mergedatasetsbycase.R
+++ b/tests/testthat/test-mergedatasetsbycase.R
@@ -1310,8 +1310,36 @@ test_that("DS-4307: Don't create multiple mergesrc variables on subsequent merge
 
 })
 
+test_that("DS-5306 Support when both data sets have meresrc variables", {
+    # Generate files with mergesrc variables "merged1.sav" and "merged2.sav"
+    MergeDataSetsByCase(data.set.names = c(findInstDirFile("cola1.sav"),
+                                           findInstDirFile("cola2.sav")),
+                        merged.data.set.name = "merged1.sav",
+                        include.merged.data.set.in.output = TRUE)
+    MergeDataSetsByCase(data.set.names = c(findInstDirFile("cola3.sav"),
+                                           findInstDirFile("cola4.sav")),
+                        merged.data.set.name = "merged2.sav",
+                        include.merged.data.set.in.output = TRUE)
+    merged.twice <- MergeDataSetsByCase(data.set.names = c("merged1.sav",
+                                                           "merged2.sav"),
+                                        include.merged.data.set.in.output = TRUE,
+                                        merged.data.set.name = "Deleteme.sav")
+    mergesrc <- merged.twice[["merged.data.set"]][["mergesrc"]]
+    expected <- structure(rep(1:4, c(327, 327, 327, 327)),
+                          "class" = c("integer", "haven_labelled"),
+                          "labels" = setNames(1:3, c("cola1.sav", "cola2.sav", "cola3.sav", "cola4.sav")),
+                          "label" = "Source of cases")
+    expect_equal(mergesrc, expected)
+})
+
 if (file.exists("Combined data set.sav"))
     file.remove("Combined data set.sav")
 
 if (file.exists("Deleteme.sav"))
     file.remove("Deleteme.sav")
+
+if (file.exists("merged1.sav"))
+    file.remove("merged1.sav")
+
+if (file.exists("merged2.sav"))
+    file.remove("merged2.sav")


### PR DESCRIPTION
- Check if the data sets which are being merged already all have a mergsrc variable. If they do, then this variable has already been merged across these files, and there is no need to add one.
- Add unit tests for this case.