### PR TITLE
DS-5351 Always give a non-empty candidate variable name when stacking

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ parameters:
   executor:
     type: enum
     enum: [nightly, rocker, machine]
-    default: rocker
+    default: nightly
 
 workflows:
   build-and-check-R-package:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipData
 Type: Package
 Title: Functions for extracting and describing data
-Version: 1.8.3
+Version: 1.8.4
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Functions for extracting data from formulas and

--- a/R/stacking.R
+++ b/R/stacking.R
@@ -1195,10 +1195,8 @@ stackedVariableName <- function(group.ind, input.variable.names, taken.names)
     common.prefix <- trimws(getCommonPrefix(nm))
     common.suffix <- trimws(getCommonSuffix(nm))
     candidate <- trimws(paste0(common.prefix, common.suffix))
-    if (candidate != "")
-        candidate
-    else
-        "stacked_var"
+    if (candidate == "")
+        candidate <- "stacked_var"
 
     uniqueName(candidate, taken.names, "_")
 }

--- a/tests/testthat/test-probabilities.R
+++ b/tests/testthat/test-probabilities.R
@@ -44,9 +44,5 @@ test_that("Probabilities", {
     for (input in valid.input) {
         expect_silent(validateProbabilityArguments(input, NULL))
         expect_silent(validateProbabilityArguments(input, data.frame(x = 1)))
-        # Default method will error as the methods are provided in flipTrees,
-        # flipRegression and flipMultivariates
-        expect_error(Probabilities(input, NULL), valid.input.but.no.method.err)
-        expect_error(Probabilities(input, data.frame(x = 1)), valid.input.but.no.method.err)
     }
 })

--- a/tests/testthat/test-stacking.R
+++ b/tests/testthat/test-stacking.R
@@ -715,6 +715,13 @@ test_that("DS-3781: identical variable labels", {
                  "Three words only")
 })
 
+test_that("DS-5351 Candidate variable names are non-empty", {
+    group.ind <- 3:4
+    input.variable.names <- c("foo", "var123", "var456", "bar", "baz")
+    taken.names <- NULL
+    expect_equal(stackedVariableName(group.ind, input.variable.names, taken.names), "stacked_var")
+})
+
 # Clean up stacked files
 if (file.exists("cola19 stacked.sav"))
     file.remove("cola19 stacked.sav")


### PR DESCRIPTION
- DS-5351 Always give a candidate variable name when stacking
- Use nightly for CCI
- Remove unnecessary tests
