### PR TITLE
RS-17155 Fix rowname checks and error message

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Description: Functions for extracting data from formulas and
         analyses.
 License: GPL-3
 LazyData: TRUE
-Depends: R (>= 4.0.0)
+Depends: R (>= 4.4.0)
 Imports: CVXR (>= 1.0.0),
  flipAPI (>= 1.3.8),
  flipFormat (>= 1.11.0),

--- a/R/combinevariablesetsasbinary.R
+++ b/R/combinevariablesetsasbinary.R
@@ -89,11 +89,14 @@ CombineVariableSetsAsBinary <- function(..., compute.for.incomplete = TRUE, unma
     input.args[["ignore.missing"]] <- TRUE
 
     # Check rownames are identical
-    input.rownames <- lapply(variable.set.list, \(x) rownames(x) %||% seq_len(NROW(x)))
-    if (!identical(Reduce(intersect, input.rownames), input.rownames[[1]])) {
-        stop("Variable sets do not have the same cases, please select variable sets from the same ",
-             "data file or ensure the case numbers are aligned between variable sets before ",
-             "using this feature")
+    input.rownames <- lapply(variable.set.list, \(x) rownames(x) %||% as.character(seq_len(NROW(x))))
+    if (!identical(Reduce(intersect, input.rownames), input.rownames[[1L]])) {
+        product <- get0("productName", envir = .GlobalEnv, ifnotfound = "Q")
+        data.naming <- if (product == "Displayr") "data source" else "data set"
+        stop("The input variables do not have the same number of cases, ",
+             "please select variables from the same ", data.naming, " ",
+             "or ensure the case numbers are aligned between variables before ",
+             "using this feature again.")
     }
 
     # Count missing values for each case for each binary variable

--- a/tests/testthat/test-combinevariablesetsasbinary.R
+++ b/tests/testthat/test-combinevariablesetsasbinary.R
@@ -182,4 +182,37 @@ test_that("Large variable sets aren't slow", {
     (CombineVariableSetsAsBinary(x, y) |>
          system.time())["elapsed"] |>
         expect_lt(1)
+    # Rownames checking works
+    x.small <- x[1:10, ] |> structure(questiontype = "PickOneMulti")
+    y.small <- y[1:10, ] |> structure(questiontype = "PickOneMulti")
+    CombineVariableSetsAsBinary(x.small, y.small) |> expect_silent()
+    # Happy with single variables
+    single.var <- factor(sample(c(NA, letters[1:3]), size = 10, replace = TRUE)) |>
+        structure(questiontype = "PickOne")
+    CombineVariableSetsAsBinary(single.var, x.small) |> expect_silent()
+    # Check rownames with error if inconsistent
+    y.offset <- y[11:20, ] |> structure(questiontype = "PickOneMulti")
+    CombineVariableSetsAsBinary(x.small, y.offset) |>
+        expect_error(
+            paste0(
+                "The input variables do not have the same number of cases, ",
+                "please select variables from the same data set"
+            )
+        )
+    assign("productName", "Displayr", envir = .GlobalEnv)
+    on.exit(rm("productName", envir = .GlobalEnv))
+    CombineVariableSetsAsBinary(x.small, y.offset) |>
+        expect_error(
+            paste0(
+                "The input variables do not have the same number of cases, ",
+                "please select variables from the same data source"
+            )
+        )
+    CombineVariableSetsAsBinary(single.var, y.offset) |>
+        expect_error(
+            paste0(
+                "The input variables do not have the same number of cases, ",
+                "please select variables from the same data source"
+            )
+        )
 })


### PR DESCRIPTION
The rowname check didn't account for the integer vs character storage or case numbers if the variable set was a single variable or data.frame respectively. This fixes the issue by making it the same data type and improves the feedback message to be platform dependent.
