### PR TITLE
Fix clarabel dependency hell

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,8 @@ workflows:
                 command: |
                   # Install rustup
                   curl https://sh.rustup.rs -sSf | bash -s -- -y
+                  # Source rustup into $PATH
+                  . "$HOME/.cargo/env" 
                   # Install the current version of Rust toolchain.
                   rustup toolchain install stable
                   rustup default stable

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,9 +40,14 @@ workflows:
                   curl https://sh.rustup.rs -sSf | bash -s -- -y
                   # Source rustup into $PATH
                   . "$HOME/.cargo/env" 
+                  rustup show
+                  # Remove existing toolchain
+                  rustup toolchain uninstall nightly-2021-09-01
                   # Install the current version of Rust toolchain.
                   rustup toolchain install stable
+                  rustup show
                   rustup default stable
+                  rustup show
       - r-packages/deploy_package:
           executor: << pipeline.parameters.executor >>
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,18 +36,16 @@ workflows:
           pre-steps:
             - run:
                 command: |
-                  # Forcibly remove rustup folder
+                  # Forcibly remove rustup folder. This avoids 'Invalid cross-device link (os error 18)' errors that seem related to Docker's execution environment - failures when moving rustup folders to /tmp/* paths. See: 
+                  # https://app.circleci.com/pipelines/github/Displayr/flipData/367/workflows/7f20ec95-3031-4fef-a52a-14ac48d54b0b/jobs/673?invite=true#step-102-1945_205
                   rm -rf /.rustup
                   # Install rustup
                   curl https://sh.rustup.rs -sSf | bash -s -- -y
                   # Source rustup into $PATH
                   . "$HOME/.cargo/env" 
                   rustup show
-                  # Remove existing toolchain
-                  rustup toolchain uninstall nightly-2021-09-01
                   # Install the current version of Rust toolchain.
                   rustup toolchain install stable
-                  rustup show
                   rustup default stable
                   rustup show
       - r-packages/deploy_package:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,9 @@ workflows:
           remote_deps: << pipeline.parameters.remote-deps >>
           separate_test_job: false
           save_snapshots: << pipeline.parameters.save-snapshots >>
+          pre-steps:
+            - run:
+                command: echo "install custom dependency"
       - r-packages/deploy_package:
           executor: << pipeline.parameters.executor >>
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,10 @@ workflows:
           save_snapshots: << pipeline.parameters.save-snapshots >>
           pre-steps:
             - run:
-                command: echo "install custom dependency"
+                command: |
+                  # Install the current version of Rust toolchain.
+                  rustup toolchain install stable
+                  rustup default stable
       - r-packages/deploy_package:
           executor: << pipeline.parameters.executor >>
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,8 @@ workflows:
           pre-steps:
             - run:
                 command: |
+                  # Forcibly remove rustup folder
+                  rm -rf /.rustup
                   # Install rustup
                   curl https://sh.rustup.rs -sSf | bash -s -- -y
                   # Source rustup into $PATH

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,8 @@ workflows:
           pre-steps:
             - run:
                 command: |
+                  # Install rustup
+                  curl https://sh.rustup.rs -sSf | bash -s -- -y
                   # Install the current version of Rust toolchain.
                   rustup toolchain install stable
                   rustup default stable


### PR DESCRIPTION
Resolves [rust toolchain based error](https://app.circleci.com/pipelines/github/Displayr/flipData/363/workflows/3374169f-30e5-4c2c-8486-f743ec402089/jobs/668?invite=true#step-109-41804_102) for `clarabel`, which comes from an indirect dependency. 

Note that a change of rust toolchain can cause different behaviour, though usually just compile time errors. My understanding is that in this job, we aren't compiling our own `rusty-rserver` code, so we don't need to use the ancient toolchain, and can use the current stable one.